### PR TITLE
Update aem.weight.edges.R

### DIFF
--- a/R/aem.weight.edges.R
+++ b/R/aem.weight.edges.R
@@ -230,6 +230,9 @@ aem.weight.edges <-
         if (is.null(beta)) {
             # First weighting function, Legendre & Legendre (2012, eq. 14.3)
             w <- 1 - (links.length/max.d)^alpha
+            if(max(links.length) > max.d){
+              stop(paste("'max.d' need to be larger than or equal to",max(links.length),"to have non-negative weights"))
+            }
         } else {
             # Second weighting function, Legendre & Legendre (2012, eq. 14.4)
             w <- 1 / links.length^beta


### PR DESCRIPTION
I just got a comment about an odd behaviour of the aem.weight.edges function; it sometimes generated negative weights. This is a behaviour that should not happen, weights should always be positive. The reason for this behaviour is that the maximum distance between two nearby site (`max(links.length)`) is larger than `max.d`. I added a trap in the code to send an error message when `max(links.length) > max.d`.