### PR TITLE
Add rownames to dbMEM

### DIFF
--- a/R/dbmem.R
+++ b/R/dbmem.R
@@ -198,7 +198,10 @@
             res <-
                 scores.listw(lw, MEM.autocor = MEM.autocor, store.listw = store.listw)
             
-            attributes(res)$row.names <- rownames(xy)
+            rownamesXY <- rownames(xy)
+            if(!is.null(rownamesXY)){
+                attributes(res)$row.names <- rownames(xy)
+            }
         })
         
         eig <- attr(res, "values")

--- a/R/dbmem.R
+++ b/R/dbmem.R
@@ -197,6 +197,8 @@
             
             res <-
                 scores.listw(lw, MEM.autocor = MEM.autocor, store.listw = store.listw)
+            
+            attributes(res)$row.names <- rownames(xy)
         })
         
         eig <- attr(res, "values")

--- a/R/stimodels.R
+++ b/R/stimodels.R
@@ -192,7 +192,7 @@
 			        cat("\n is useless. They are replaced by a vector of Helmert contrasts\n\n")
 			    } 
 			    else {
-			        dbMEM.S.tmp <- dbmem(sitesX, MEM.autocor="positive")
+			      dbMEM.S.tmp <- dbmem(sitesX, MEM.autocor="positive")
 				    SS <- as.matrix(dbMEM.S.tmp)
 				    dbMEM.S.thresh <- give.thresh(dist(sitesX))
 				    if(print.res) cat(" Truncation level for space dbMEMs =", dbMEM.S.thresh, "\n")


### PR DESCRIPTION
Through a question to a user, I noticed that row names were not included when constructing db-MEM. I added one line in the code to correct this.