### PR TITLE
Changes void to extern void in cclust function declaration and defini…

### DIFF
--- a/src/constr.hclust.c
+++ b/src/constr.hclust.c
@@ -858,9 +858,9 @@ void hcass2(int *n, int *ia, int *ib, int *iorder, int *iia, int *iib) {
 
 // Service function to be called by R wrapper function: constr.hclust
 // (flashClust version)
-void cclust(int* n, int* merge, double* height, int* order, double* diss0,
-            int* nl, int* linkl, int* method, double* par, int* type,
-            int* membr) {
+extern void cclust(int* n, int* merge, double* height, int* order,
+		   double* diss0, int* nl, int* linkl, int* method, double* par,
+		   int* type, int* membr) {
   int* flag = (int*)R_alloc(*n,sizeof(int));
   int* ia = (int*)R_alloc(*n-1,sizeof(int));
   int* ib = (int*)R_alloc(*n-1,sizeof(int));

--- a/src/constr.hclust.h
+++ b/src/constr.hclust.h
@@ -149,9 +149,9 @@ void constClustLS(int* n, int* membr, int* ia, int* ib, double* crit, int* m,
 void hcass2(int* n, int* ia, int* ib, int* iorder, int* iia, int* iib);
 
 // R wrapper function (called from R using the .C() interface)
-void cclust(int* n, int* merge, double* height, int* order, double* diss0,
-            int* nl, int* linkl, int* method, double* par, int* type,
-            int* membr);
+extern void cclust(int* n, int* merge, double* height, int* order,
+		   double* diss0, int* nl, int* linkl, int* method, double* par,
+		   int* type, int* membr);
 
 #ifdef with_LS
 void cclustLS(int* n, int* merge, double* height, int* order, int* m,


### PR DESCRIPTION
Bonjour Stéphane,

Ces changements devraient régler le warning qui apparaît lors du "linking" à la fin de la compilation du code C.

Il y avait un désaccord entre ce qui était déclaré dans init.c et ce qui se trouvait dans constr.hclust.c et constr.hclust.h. Le problème n'était donc pas visible lors de la compilation de constr.hclust mais surgissait lors du linking de l'ensemble des fichiers C vers le shared object.

Dis-moi si ça règle le problème de ton côté. Du mien, tout semble K du moins.

Bonne fin de journée,

Guillaume.