### PR TITLE
Add return statement for LCBD.comp

### DIFF
--- a/R/LCBD.comp.R
+++ b/R/LCBD.comp.R
@@ -177,4 +177,5 @@ LCBD.comp <- function(D, sqrt.D = TRUE, save.D = FALSE) {
     } else {
         out <- list(beta = beta, LCBD = LCBD)
     }
+    out
 }


### PR DESCRIPTION
Hi!

I've notice a strange behavior of the `LCBD.comp()` function. When I tried `LCBD.comp(D)` in the terminal I didn't have any returned values.

I figured out that the `out` object was not evaluated last (maybe due to the else statement). Therefore, it  was not returned by the function.

This small PR fix it.