### PR TITLE
spdep-devel moves sp from depends to suggests

### DIFF
--- a/vignettes/tutorial.Rmd
+++ b/vignettes/tutorial.Rmd
@@ -38,6 +38,7 @@ library(ade4)
 library(adespatial)
 library(adegraphics)
 library(spdep)
+library(sp)
 ```
 
 # The Mafragh data set


### PR DESCRIPTION
`vignettes/tutorial.Rmd` uses **sp** without requiring it, because **spdep** has depended on **sp**. This is mis-understood as meaning that only `"Spatial"` objects can be used with **spdep**, so **sp** is moving from `Depends:` to `Suggests:` in **spdep**.