### PR TITLE
Add website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     vegan
 Suggests: knitr, ape, rmarkdown, betapart
 License: GPL (>= 2)
-URL: https://github.com/sdray/adespatial
+URL: https://github.com/sdray/adespatial, http://sdray.github.io/adespatial/
 BugReports: https://github.com/sdray/adespatial/issues
 Encoding: UTF-8
 NeedsCompilation: yes


### PR DESCRIPTION
You can look in the GitHub pages setting to enable https instead of http?

You can also add this link in the About section of the github homepage.

![image](https://github.com/sdray/adespatial/assets/52606734/786abb4d-7f36-420d-ac2f-bd3390ad5d86)
