### PR TITLE
Added #include<stdbool.h> instead of custom definition for Boolean va…

### DIFF
--- a/src/constr.hclust.c
+++ b/src/constr.hclust.c
@@ -49,6 +49,7 @@
 
 #include<R.h>
 #include<Rmath.h>
+#include<stdbool.h>
 #include"constr.hclust.h"
 
 /*

--- a/src/constr.hclust.h
+++ b/src/constr.hclust.h
@@ -45,8 +45,8 @@
 // #define testing      // Enables testing functions (useful during development)
 // #define show_links
 // Shows links before and after the clustering function to check link updating
-#define true -1
-#define false 0
+// #define true -1
+// #define false 0
 #define INTMOD 16    // Interval to check for user interruption request
 
 // General accessory functions


### PR DESCRIPTION
This will hopefully solve the warning from clang compiler (MacOS).